### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,6 @@ jobs:
         with:
           node-version: 16
           cache: npm
-      - run: npx semantic-release
+      - run: npx -p node@v18-lts -c "npx semantic-release"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
fix Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-node@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.